### PR TITLE
Eliminated Foody + VRISING.GAMEDATA

### DIFF
--- a/RPGAddOns/FodyWeavers.xml
+++ b/RPGAddOns/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-	<ILMerge NamespacePrefix="BloodyPoints_" IncludeAssemblies="VRising.GameData"></ILMerge>
-</Weavers>

--- a/RPGAddOns/Patch/ServerEvents.cs
+++ b/RPGAddOns/Patch/ServerEvents.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+using ProjectM;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Unity.Entities;
+
+namespace RPGAddOns.Patch
+{
+
+    public delegate void OnGameDataInitializedEventHandler(World world);
+
+    internal class ServerEvents
+    {
+        internal static event OnGameDataInitializedEventHandler OnGameDataInitialized;
+
+        [HarmonyPatch(typeof(LoadPersistenceSystemV2), nameof(LoadPersistenceSystemV2.SetLoadState))]
+        [HarmonyPostfix]
+        private static void ServerStartupStateChange_Postfix(ServerStartupState.State loadState, LoadPersistenceSystemV2 __instance)
+        {
+            try
+            {
+                if (loadState == ServerStartupState.State.SuccessfulStartup)
+                {
+                    OnGameDataInitialized?.Invoke(__instance.World);
+                }
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogError(ex);
+            }
+        }
+    }
+}

--- a/RPGAddOns/Plugin.cs
+++ b/RPGAddOns/Plugin.cs
@@ -3,10 +3,10 @@ using BepInEx.Logging;
 using BepInEx.Unity.IL2CPP;
 using Bloodstone.API;
 using HarmonyLib;
+using RPGAddOns.Patch;
 using System.Reflection;
 using Unity.Entities;
 using VampireCommandFramework;
-using VRising.GameData;
 
 namespace RPGAddOns
 {
@@ -50,8 +50,7 @@ namespace RPGAddOns
             CommandRegistry.RegisterAll();
             harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
             harmony.PatchAll(Assembly.GetExecutingAssembly());
-            GameData.OnInitialize += GameDataOnInitialize;
-            GameData.OnDestroy += GameDataOnDestroy;
+            ServerEvents.OnGameDataInitialized += GameDataOnInitialize;
 
             if (!VWorld.IsServer)
             {
@@ -63,11 +62,6 @@ namespace RPGAddOns
 
             // Plugin startup logic
             Log.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded!");
-        }
-
-        private void GameDataOnDestroy()
-        {
-
         }
 
         private void GameDataOnInitialize(World world)

--- a/RPGAddOns/RPGAddOns.csproj
+++ b/RPGAddOns/RPGAddOns.csproj
@@ -18,12 +18,7 @@
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />
     <PackageReference Include="BepInEx.Unity.Common" Version="6.0.0-be.668" />
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.668" />
-    <PackageReference Include="Fody" Version="6.7.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="HarmonyX" Version="2.10.1" />
-    <PackageReference Include="ILMerge.Fody" Version="1.24.0" />
     <PackageReference Include="VRising.Bloodstone" Version="0.1.6" />
     <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.5.57575090" />
     <PackageReference Include="VRising.VampireCommandFramework" Version="0.8.2" />
@@ -35,9 +30,6 @@
     </Reference>
     <Reference Include="RPGMods">
       <HintPath>..\..\..\..\Downloads\RPGMods.dll</HintPath>
-    </Reference>
-    <Reference Include="VRising.GameData">
-      <HintPath>..\..\BloodyPointsTesting\VRising.GameData.dll</HintPath>
     </Reference>
   </ItemGroup>
 	<Target Name="CopyDLLsServer" AfterTargets="Build">


### PR DESCRIPTION
You are using VRising.GameData.dll only for GameDataOnInitialize, perhaps it is better to patch with harmony than overloading the DLL with this Framework + Foody.